### PR TITLE
Migrate the deps image to trixie

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -48,7 +48,7 @@ jobs:
           images: ${{ env.DOCKER_IMAGE }}
           # Docker tags based on the following events/attributes
           tags: |
-            type=raw,value=latest
+            type=raw,value=trixie
             type=sha
 
       - name: Detect dependency versions

--- a/dependencies/Dockerfile
+++ b/dependencies/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM:-linux/amd64} debian:bookworm-slim AS base-prep
+FROM --platform=${BUILDPLATFORM:-linux/amd64} debian:trixie-slim AS base-prep
 ARG TARGETPLATFORM
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 COPY --chmod=0755 prepare.sh /tmp/
@@ -65,5 +65,5 @@ COPY --from=download-jellyfin-ffmpeg /output/ /output/
 COPY --chmod=0755 output.sh /
 RUN /output.sh
 
-FROM debian:bookworm-slim AS release
+FROM debian:trixie-slim AS release
 COPY --from=final-assembly /artifacts.tar.gz /

--- a/dependencies/download_jellyfin-ffmpeg.sh
+++ b/dependencies/download_jellyfin-ffmpeg.sh
@@ -29,7 +29,7 @@ echo Compiler: "${DEB_HOST_GNU_TYPE}" Arch: "${DEB_HOST_ARCH}"
 
 VER="${JELLYFIN_FFMPEG_VERSION#v}"
 MAJOR_VER=$(echo "${VER}" | cut -d. -f1)
-URL="https://github.com/jellyfin/jellyfin-ffmpeg/releases/download/${JELLYFIN_FFMPEG_VERSION}/jellyfin-ffmpeg${MAJOR_VER}_${VER}-bookworm_${DEB_HOST_ARCH}.deb"
+URL="https://github.com/jellyfin/jellyfin-ffmpeg/releases/download/${JELLYFIN_FFMPEG_VERSION}/jellyfin-ffmpeg${MAJOR_VER}_${VER}-trixie_${DEB_HOST_ARCH}.deb"
 echo download jellyfin-ffmpeg from "$URL"
 mkdir -p /output/deb
 curl -fsSL --retry 2 --retry-delay 5 --retry-max-time 60 -o /output/deb/jellyfin-ffmpeg.deb "$URL"

--- a/dependencies/prepare.sh
+++ b/dependencies/prepare.sh
@@ -10,6 +10,7 @@ if [ "$TARGETARCH" = "arm" ]; then
   DEBIAN_ARCH=armel
 fi
 
+export DEBIAN_FRONTEND=noninteractive
 dpkg --add-architecture "$DEBIAN_ARCH"
 apt-get update
 apt-get install -y \
@@ -18,6 +19,7 @@ apt-get install -y \
   ca-certificates \
   crossbuild-essential-"${DEBIAN_ARCH}" \
   libc-dev:"${DEBIAN_ARCH}" \
+  dpkg-dev \
   autoconf \
   automake \
   libtool \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated base OS to Debian Trixie across the build and release workflow.
  * Published Docker images now use the “trixie” tag instead of “latest.”
  * Aligned FFmpeg dependency source with the new OS version.
  * Made package installation non-interactive and ensured required tooling is installed to improve build stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->