### PR TITLE
Fix Browserlist CI job

### DIFF
--- a/.github/workflows/update-browserslist.yml
+++ b/.github/workflows/update-browserslist.yml
@@ -18,14 +18,6 @@ jobs:
         with:
           node-version: '18'
 
-      - name: Cache npm dependencies
-        uses: actions/cache@v4
-        with:
-          path: ./ui/node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('./ui/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
       - name: Install dependencies
         working-directory: ./ui
         run: npm ci
@@ -44,12 +36,12 @@ jobs:
           fi
 
       - name: Create Pull Request
-        if: steps.changes.outputs.changes == 'true'
+        if: ${{ steps.changes.outputs.changes == 'true' }}
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.COMMENT_TOKEN }}
-          commit-message: 'chore: update browserslist database'
-          title: 'chore: update browserslist database'
+          commit-message: 'Bump browserslist database'
+          title: 'Bump browserslist database'
           branch: update-browserslist-db
           delete-branch: true
           labels: 'dependencies, javascript'

--- a/.github/workflows/update-browserslist.yml
+++ b/.github/workflows/update-browserslist.yml
@@ -6,6 +6,10 @@ on:
     - cron: '18 1 * * 5'
   workflow_dispatch: # Allows manual triggering
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update-browserslist:
     runs-on: ubuntu-latest
@@ -24,7 +28,7 @@ jobs:
 
       - name: Update browserslist database
         working-directory: ./ui
-        run: npx update-browserslist-db@latest
+        run: npx --yes update-browserslist-db@latest
 
       - name: Check for changes
         id: changes

--- a/.github/workflows/update-browserslist.yml
+++ b/.github/workflows/update-browserslist.yml
@@ -17,7 +17,14 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '18'
-          cache: 'npm'
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v4
+        with:
+          path: ./ui/node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('./ui/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
 
       - name: Install dependencies
         working-directory: ./ui


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - CI workflow updated to add explicit permissions and to run the browserslist update non-interactively.
  - Workflow now uses standardized wording "Bump browserslist database" for PR title and commit message and a corrected condition check for PR creation.
  - Removed an npm cache option.
  - No user-facing functionality or behavior changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->