### PR TITLE
Merge upstream 14 oct

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,18 @@ When your media has been scanned, they show up on the website, organized in the 
 > If you have questions regarding setup or development,
 feel free to start or join a discussion in this repo
 
+# ATTENTION to PostgreSQL users !!!
+
+We switched to PostgreSQL 18 on the `master` branch. PostgreSQL 18 will be the default recommended version
+for the next release (PostgreSQL 17 remains supported). If you follow `master`, please check the
+[official PostgreSQL upgrade guide](https://www.postgresql.org/docs/current/upgrading.html), and:
+
+- For Docker users: please update your `docker-compose.yml` to match [docker-compose.example.yml](./docker-compose%20example/docker-compose.example.yml).
+- Please pay attention to the DB volume mount point change inside the container: starting from version 18, the DB is mounted to the `/var/lib/postgresql`, while in earlier versions it was the `/var/lib/postgresql/data`.
+- For direct host installations or external/shared PostgreSQL instances: please upgrade your PostgreSQL server and database manually to version 18 following PostgreSQL guidance.
+
+Don't forget to back up your database before upgrading.
+
 ## Terms of use
 
 By using this project or its source code, for any purpose and in any shape or form, you grant your **implicit agreement** to all of the following statements:
@@ -65,26 +77,27 @@ Glory to Ukraine! 🇺🇦
 
 ## Contents
 
-- [Terms of use](#terms-of-use)
-- [Contents](#contents)
-- [Main features](#main-features)
-- [Supported platforms](#supported-platforms)
-- [Supported databases](#supported-databases)
-- [Why yet another self-hosted photo gallery](#why-yet-another-self-hosted-photo-gallery)
-- [Getting started — Setup with Docker](#getting-started--setup-with-docker)
-  - [Initial Setup](#initial-setup)
-- [Advanced setup](#advanced-setup)
-  - [Hardware Acceleration](#hardware-acceleration)
-- [Contributing](#contributing)
-- [Set up Docker development environment](#set-up-docker-development-environment)
-  - [Start API and UI server with Docker Compose](#start-api-and-ui-server-with-docker-compose)
-  - [Start API server with Docker](#start-api-server-with-docker)
-  - [Start UI server with Docker](#start-ui-server-with-docker)
-- [Set up local development environment](#set-up-local-development-environment)
-  - [Install dependencies](#install-dependencies)
-  - [Local setup](#local-setup)
-  - [Start API server](#start-api-server)
-  - [Start UI server](#start-ui-server)
+- [ATTENTION to PostgreSQL users !!!](#attention-to-postgresql-users-)
+  - [Terms of use](#terms-of-use)
+  - [Contents](#contents)
+  - [Main features](#main-features)
+  - [Supported platforms](#supported-platforms)
+  - [Supported databases](#supported-databases)
+  - [Why yet another self-hosted photo gallery](#why-yet-another-self-hosted-photo-gallery)
+  - [Getting started — Setup with Docker](#getting-started--setup-with-docker)
+    - [Initial Setup](#initial-setup)
+  - [Advanced setup](#advanced-setup)
+    - [Hardware Acceleration](#hardware-acceleration)
+  - [Contributing](#contributing)
+  - [Set up Docker development environment](#set-up-docker-development-environment)
+    - [Start API and UI server with Docker Compose](#start-api-and-ui-server-with-docker-compose)
+    - [Start API server with Docker](#start-api-server-with-docker)
+    - [Start UI server with Docker](#start-ui-server-with-docker)
+  - [Set up local development environment](#set-up-local-development-environment)
+    - [Install dependencies](#install-dependencies)
+    - [Local setup](#local-setup)
+    - [Start API server](#start-api-server)
+    - [Start UI server](#start-ui-server)
 
 ## Main features
 
@@ -115,7 +128,7 @@ We provide limited support for the standard deployment scenarios on the platform
 
 - [SQLite](https://sqlite.org/): built-in DBMS, no additional service or maintenance required; lowest performance and no scalability.
 - [MariaDB](https://mariadb.org/) LTS version: default choice. Runs as an additional service; good balance between performance and maintenance effort.
-- [PostgreSQL](https://www.postgresql.org/) 16 and 17: typically the best performance. Runs as an additional service; requires slightly more maintenance.
+- [PostgreSQL](https://www.postgresql.org/) 18 and 17: typically the best performance. Runs as an additional service; requires slightly more maintenance.
 
 We support running Photoview with one of these DBMSs when used as a dedicated instance for Photoview only.
 If you share a DBMS among multiple services, our support is limited to SQL issues. DB management and connection-related

--- a/api/scanner/externaltools/exif/exif.go
+++ b/api/scanner/externaltools/exif/exif.go
@@ -1,7 +1,6 @@
 package exif
 
 import (
-	"context"
 	"fmt"
 	"sync"
 
@@ -22,7 +21,7 @@ func Initialize() (func(), error) {
 		return nil, err
 	}
 
-	log.Info(context.Background(), "Found exiftool")
+	log.Info(nil, "Found exiftool")
 
 	return func() {
 		globalMu.Lock()
@@ -33,7 +32,7 @@ func Initialize() (func(), error) {
 		}
 
 		if err := globalExifParser.Close(); err != nil {
-			log.Error(context.Background(), "Cleanup exiftool error", "error", err)
+			log.Error(nil, "Cleanup exiftool error", "error", err)
 			return
 		}
 		globalExifParser = nil
@@ -56,7 +55,7 @@ func Parse(filepath string) (*models.MediaEXIF, error) {
 	}
 
 	if len(failures) > 0 {
-		log.Warn(context.Background(), "Parse exif failures", "filepath", filepath, "errors", failures)
+		log.Warn(nil, "Parse exif failures", "file_path", filepath, "errors", failures)
 	}
 
 	return exif, nil

--- a/api/scanner/scanner_tasks/exif_task.go
+++ b/api/scanner/scanner_tasks/exif_task.go
@@ -1,6 +1,7 @@
 package scanner_tasks
 
 import (
+	"errors"
 	"fmt"
 
 	"gorm.io/gorm"
@@ -31,20 +32,21 @@ func (t ExifTask) AfterMediaFound(ctx scanner_task.TaskContext, media *models.Me
 func SaveEXIF(tx *gorm.DB, media *models.Media) error {
 	// Check if EXIF data already exists
 	if media.ExifID != nil {
-		var exifInDB models.MediaEXIF
-		if err := tx.First(&exifInDB, media.ExifID).Error; err == nil {
+		var e models.MediaEXIF
+		var err error
+		if err = tx.First(&e, media.ExifID).Error; err == nil {
 			return nil
-		} else if err != gorm.ErrRecordNotFound {
-			return fmt.Errorf("failed to get EXIF for %q from database: %w", media.Path, err)
-		} else {
-			log.Warn(
-				tx.Statement.Context,
-				"EXIF metadata not found in database, will re-parse it",
-				"path", media.Path,
-				"error", err,
-			)
-			media.ExifID = nil
 		}
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return fmt.Errorf("failed to get EXIF for %q from database: %w", media.Path, err)
+		}
+		log.Warn(
+			tx.Statement.Context,
+			"EXIF metadata not found in database, will re-parse it",
+			"path", media.Path,
+			"error", err,
+		)
+		media.ExifID = nil
 	}
 
 	exifData, err := exif.Parse(media.Path)
@@ -62,11 +64,10 @@ func SaveEXIF(tx *gorm.DB, media *models.Media) error {
 	}
 
 	if exifData.DateShot != nil && !exifData.DateShot.Equal(media.DateShot) {
-		if err := tx.Model(media).Update("date_shot", *exifData.DateShot).Error; err != nil {
-			return fmt.Errorf("failed to update media date_shot: %w", err)
-		} else {
-			media.DateShot = *exifData.DateShot
+		if err := tx.Save(media).Error; err != nil {
+			return fmt.Errorf("failed to update EXIF metadata for the media %s: %w", media.Path, err)
 		}
+		media.DateShot = *exifData.DateShot
 	}
 
 	return nil

--- a/docker-compose example/docker-compose.example.yml
+++ b/docker-compose example/docker-compose.example.yml
@@ -140,7 +140,7 @@ services:
   ## Uncomment the `postgres-autoupgrade` service if you want to upgrade PostgreSQL automatically, or follow the
   ## official PostgreSQL upgrade guide https://www.postgresql.org/docs/current/upgrading.html manually.
   ## Don't forget to uncomment the 3 `depends_on` lines in the `postgres` service.
-  ## This service will upgrade the PostgreSQL database to the version 17.
+  ## This service will upgrade the PostgreSQL database to the version, specified in the `image` tag.
   ## Read more on the https://hub.docker.com/r/pgautoupgrade/pgautoupgrade
   ## Tip: Back up the Photoview data before autoupgrade to a new PostgreSQL version.
   ## It is an optional service to simplify the upgrade process. You can also upgrade PostgreSQL manually.

--- a/ui/src/components/timelineGallery/TimelineGallery.tsx
+++ b/ui/src/components/timelineGallery/TimelineGallery.tsx
@@ -141,7 +141,7 @@ const TimelineGallery = () => {
 
   urlPresentModeSetupHook({
     dispatchMedia,
-    openPresentMode: () => {
+    openPresentMode: (_event) => {
       dispatchMedia({
         type: 'openPresentMode',
         activeIndex: mediaState.activeIndex as unknown as TimelineMediaIndex,

--- a/ui/src/extractedTranslations/pt/translation.json
+++ b/ui/src/extractedTranslations/pt/translation.json
@@ -5,7 +5,7 @@
     "sort_by": "Ordenado por",
     "sort_direction": "Sentido da ordenação",
     "order_direction": {
-      "ascending": "Crescente",
+      "ascending": "Ascendente",
       "descending": "Decrescente"
     },
     "sorting_options": {
@@ -187,7 +187,7 @@
       },
       "confirm_delete_user": {
         "action": "Apagar {{user}}",
-        "description": "<0>Tem a certeza que pretende apagar <1></1>?</0><p>Esta ação não pode ser desfeita</p>",
+        "description": "<0>Tem a certeza de que pretende apagar <1></1>?</0><p>Esta ação não pode ser desfeita.</p>",
         "title": "Apagar utilizador"
       },
       "password_reset": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Added a prominent PostgreSQL upgrade notice, including Docker Compose guidance, volume-mount changes, and backup reminder.
  * Updated supported PostgreSQL versions to 18 (default) and 17.
  * Clarified postgres-autoupgrade behavior in the Docker Compose example; noted it exits immediately if no upgrade is needed.

* Style
  * Improved Portuguese translations: refined “ascending” wording and polished the user deletion confirmation text for clarity and punctuation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->