### PR TITLE
Docker Scout action for PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,7 +183,7 @@ jobs:
 
       - name: Docker Scout report
         id: scout_report
-        if: ${{ steps.docker_buildx.conclusion == 'success'}}
+        if: ${{ steps.docker_buildx.conclusion == 'success' }}
         uses: docker/scout-action@v1
         with:
           command: cves


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Docker Scout Action for Pull Requests

## Summary
This PR integrates Docker Scout into the build workflow (.github/workflows/build.yml) to run container security scans for PR images and publish results to Code Scanning. Key changes:
- Add docker/scout-action@v1 to run "cves" per matrix image and produce SARIF (sarif.scout.<build_target>.json), uploaded via github/codeql-action/upload-sarif@v4.
- Scan targets are explicitly set: for PRs the action scans the locally produced OCI output (oci-dir://./image-<target>); for non-PR runs it scans the published image tag resolved from docker/metadata-action.
- Images are referenced directly from the matrix (matrix.entry.image) and docker/metadata-action uses matrix.entry.image for images metadata.
- Removed registry-branching logic and DOCKER_REGISTRY usage; Docker login simplified to always use DOCKER_USERNAME/DOCKER_PASSWORD.
- Dockle container checks remain but are gated to non-pull_request runs (if: github.event_name != 'pull_request').
- Workflow tweaks: OCI export outputs for PR builds, cron quoting fixed, minor formatting adjustments, and the prior PR comment-posting behavior is replaced by SARIF/Checks artifacts (scan quickviews appear in comments/artifacts produced by the action).

## Benefits for the product (changes introduced by this PR)
- PR-scoped image scanning: Each PR build runs Scout against the exact image produced by that PR (via OCI export), making regressions in image composition visible during review.
- Persistent, discoverable findings: SARIF uploads push Scout results into GitHub Code Scanning (Checks) so results are retained, searchable, and available to reviewers and audit workflows.
- Simpler CI logic: Removing DOCKER_REGISTRY branching and consolidating login logic reduces workflow branching and surface area for errors in build steps.
- Clearer reviewer signals: The Scout quickview + SARIF in Checks provides a standardized place to inspect image-level findings without running local tooling.

## Risks and considerations (limited to this PR's changes)
- Visibility change (PR comment removal): The workflow no longer reliably posts the rich PR comment; reviewers must look at Checks / Code Scanning SARIF artifacts or the Scout quickview if the action posts one. This may be overlooked in current review flows.
- Dockle not run for PRs: Dockle checks are explicitly skipped for pull_request events, so image best-practice findings from Dockle won't appear during PR review unless the gating condition is changed.
- Registry flexibility reduced: Removing DOCKER_REGISTRY and using matrix.entry.image directly reduces flexibility to target alternate registries or registry-prefixed image names; consumers relying on registry-prefixed logic may need workflow or matrix updates.
- Secret and action dependency: The new flow requires DOCKER_USERNAME and DOCKER_PASSWORD in secrets and depends on external actions (docker/scout-action, codeql upload). Missing secrets or action availability will cause scan/upload steps to fail and may alter CI behavior.
- SARIF permission requirements: Uploading SARIF requires appropriate token scopes/permissions; insufficient token permissions will prevent findings from appearing in Code Scanning and could hide scan results from reviewers.
- CI output/noise trade-off: Adding Scout + SARIF increases scan output in Checks; teams should decide whether to treat findings as informational or pipeline-failing to avoid noisy or blocked PRs.

## Overall assessment
This PR adds PR-time, SARIF-backed container scanning and simplifies image handling in CI, improving security visibility for changes that alter built images. Before merging, confirm required secrets and token scopes are present, communicate where to find SARIF/Checks output to reviewers, and decide whether to run Dockle on PRs or leave it gated to non-PR runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->