### PR TITLE
Allow secrets in PRs from the same repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
           # Prepare the tags matrix
           case ${{ github.event_name }} in
             pull_request_target)
-              TAGS='[{"tag": "", "ref": "${{ github.ref }}"}]'
+              TAGS='[{"tag": "", "ref": "refs/pull/${{ github.event.pull_request.number }}/head"}]'
               ;;
             push)
               TAGS='[{"tag": "${{ github.ref_name }}", "ref": "${{ github.ref }}"}]'
@@ -136,7 +136,7 @@ jobs:
 
       - name: Docker Login
         uses: docker/login-action@v3
-        if: github.repository == github.event.pull_request.head.repo.full_name
+        if: ${{ github.event_name != 'pull_request_target' || github.repository == github.event.pull_request.head.repo.full_name }}
         with:
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ env.DOCKER_PASSWORD }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR updates the repository's GitHub Actions build workflow so steps that require repository secrets can run for pull requests opened from the same repository. The core change is shifting PR-related triggers and conditional checks from pull_request to pull_request_target and adding checks that ensure secret-using steps only run when the PR head repo equals the base repo.

Summary of changes
- Workflow trigger/event changes: replaced pull_request usage with pull_request_target in the workflow and many job conditions.
- Conditional gating updates: adjusted IS_PUSHING_IMAGES and multiple step/job conditions to treat pull_request_target consistently.
- Matrix/branch logic: preparation and branch-case handling changed to use pull_request_target contexts and PR head refs where needed.
- Secret-guarded steps modified to run only when the PR originates from the main repo (github.repository == github.event.pull_request.head.repo.full_name), including:
  - SonarCloud scan
  - Docker login and image push steps
  - Dockle and Docker Scout/image lookup steps
  - Build output and image-output conditionals
- Numerous conditional references throughout the workflow were aligned to support the new pull_request_target path while preserving non-PR and fork PR behavior.

Product-focused benefits (changes introduced by this PR)
- CI completeness for internal PRs: Contributors opening PRs from the main repo will get full CI (scans, image build/push, container analysis) without requiring maintainers to run privileged steps manually.
- Faster, richer feedback: Security scans and artifact/image outputs become available on internal PRs, improving reviewers’ ability to validate changes before merge.
- Fork safety preserved: Fork-origin PRs remain prevented from accessing repository secrets because steps are gated to require the PR head repo to match the base repo.

Product-focused risks (changes introduced by this PR)
- Increased attack surface via workflow execution context: Using pull_request_target causes the workflow code from the base branch to run with repository secrets for matching-repo PRs; if the base branch workflow is compromised, secrets could be exfiltrated.
- Conditional complexity and undefined-field edge cases: Many conditions now reference pull_request-specific fields (e.g., github.event.pull_request.head.repo.full_name) or pull_request_target; if any condition is miswritten or evaluated in non-PR contexts, secret-using steps may be skipped silently or generate confusing CI behavior, complicating troubleshooting.
- More CI runs and cost surface: Enabling pull_request_target paths may increase workflow invocations and the number of conditional evaluations, potentially raising CI runtime and cost even though secret-using steps are gated.
- Maintenance fragility: The distributed mix of pull_request_target vs. other event checks across jobs raises the chance that future edits inadvertently relax gating and enable secrets for unintended cases.

Testing / QA pointers (to validate changes)
- Create a PR from the main repository and confirm SonarCloud, Docker login/push, Dockle and image-related steps execute and succeed.
- Create a PR from a fork and confirm those secret-using steps are skipped while the workflow still runs.
- Run non-PR events (push, schedule) and confirm no steps fail because pull_request fields are undefined.
- Review the workflow for any conditional references that could evaluate incorrectly in non-PR contexts and add safe guards or explicit event checks where necessary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->