### PR TITLE
Fix Sonar issues

### DIFF
--- a/ui/src/Pages/PeoplePage/SingleFaceGroup/MergeFaceGroupsModal.test.tsx
+++ b/ui/src/Pages/PeoplePage/SingleFaceGroup/MergeFaceGroupsModal.test.tsx
@@ -361,7 +361,7 @@ describe('MergeFaceGroupsModal', () => {
             expect(screen.queryByTestId('modal')).not.toBeInTheDocument()
         })
 
-        test('closes and reports invalid SelectPreselectedRole state without rendering', async () => {
+        test('reports invalid SelectPreselectedRole state without rendering', () => {
             const setState = vi.fn()
             const consoleErrorSpy = vi
                 .spyOn(console, 'error')
@@ -378,11 +378,7 @@ describe('MergeFaceGroupsModal', () => {
 
                 expect(screen.queryByTestId('modal')).not.toBeInTheDocument()
 
-                await waitFor(() => {
-                    expect(setState).toHaveBeenCalledWith(
-                        MergeFaceGroupsModalState.Closed
-                    )
-                })
+                expect(setState).not.toHaveBeenCalled()
 
                 expect(consoleErrorSpy).toHaveBeenCalledWith(
                     'MergeFaceGroupsModal opened with SelectPreselectedRole state but no preselectedFaceGroup'

--- a/ui/src/Pages/PeoplePage/SingleFaceGroup/MergeFaceGroupsModal.tsx
+++ b/ui/src/Pages/PeoplePage/SingleFaceGroup/MergeFaceGroupsModal.tsx
@@ -1,5 +1,5 @@
 import { gql, PureQueryOptions, useMutation, useQuery } from '@apollo/client'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router'
 import { isNil } from '../../../helpers/utils'
@@ -58,7 +58,26 @@ type PreselectedFaceGroupRole = 'source' | 'destination' | null
 const FACE_GROUP_PAGE_SIZE = 50
 const MODAL_SCROLL_ROOT_MARGIN = '0px 0px 160px 0px'
 
-const MergeFaceGroupsModal = ({
+const MergeFaceGroupsModal = (props: MergeFaceGroupsModalProps) => {
+  const { state, preselectedFaceGroup } = props
+
+  if (state === MergeFaceGroupsModalState.Closed) {
+    return null
+  }
+
+  if (
+    state === MergeFaceGroupsModalState.SelectPreselectedRole && !preselectedFaceGroup
+  ) {
+    console.error(
+      'MergeFaceGroupsModal opened with SelectPreselectedRole state but no preselectedFaceGroup'
+    )
+    return null
+  }
+
+  return <MergeFaceGroupsModalContent {...props} />
+}
+
+const MergeFaceGroupsModalContent = ({
   state,
   setState,
   preselectedFaceGroup,
@@ -66,9 +85,6 @@ const MergeFaceGroupsModal = ({
 }: MergeFaceGroupsModalProps) => {
   const { t } = useTranslation()
   const navigate = useNavigate()
-
-  const hasMissingPreselectedRole =
-    state === MergeFaceGroupsModalState.SelectPreselectedRole && !preselectedFaceGroup
 
   const {
     data,
@@ -143,18 +159,6 @@ const MergeFaceGroupsModal = ({
     setState(MergeFaceGroupsModalState.Closed)
     resetModalState()
   }, [isMerging, resetModalState, setState])
-
-  useEffect(() => {
-    if (!hasMissingPreselectedRole) return
-    console.error('MergeFaceGroupsModal opened with SelectPreselectedRole state but no preselectedFaceGroup')
-    setState(MergeFaceGroupsModalState.Closed)
-    //TODO: Fix the "Calling setState synchronously in useEffect may cause unexpected behavior" issue
-    resetModalState()
-  }, [hasMissingPreselectedRole, resetModalState, setState])
-
-  if (hasMissingPreselectedRole) {
-    return null
-  }
 
   const cancelAction: ModalAction = {
     key: 'cancel',

--- a/ui/src/Pages/PeoplePage/SingleFaceGroup/MergeFaceGroupsModal.tsx
+++ b/ui/src/Pages/PeoplePage/SingleFaceGroup/MergeFaceGroupsModal.tsx
@@ -58,6 +58,9 @@ type PreselectedFaceGroupRole = 'source' | 'destination' | null
 const FACE_GROUP_PAGE_SIZE = 50
 const MODAL_SCROLL_ROOT_MARGIN = '0px 0px 160px 0px'
 
+// Thin outer wrapper: only mounts the stateful modal content for valid, open
+// states. This deliberately avoids effect-driven setState (see PR discussion)
+// and gives the inner component fresh local state on every (re)mount.
 const MergeFaceGroupsModal = (props: MergeFaceGroupsModalProps) => {
   const { state, preselectedFaceGroup } = props
 

--- a/ui/src/Pages/PeoplePage/SingleFaceGroup/MergeFaceGroupsModal.tsx
+++ b/ui/src/Pages/PeoplePage/SingleFaceGroup/MergeFaceGroupsModal.tsx
@@ -148,6 +148,7 @@ const MergeFaceGroupsModal = ({
     if (!hasMissingPreselectedRole) return
     console.error('MergeFaceGroupsModal opened with SelectPreselectedRole state but no preselectedFaceGroup')
     setState(MergeFaceGroupsModalState.Closed)
+    //TODO: Fix the "Calling setState synchronously in useEffect may cause unexpected behavior" issue
     resetModalState()
   }, [hasMissingPreselectedRole, resetModalState, setState])
 

--- a/ui/src/components/sidebar/MediaSidebar/MediaSidebar.tsx
+++ b/ui/src/components/sidebar/MediaSidebar/MediaSidebar.tsx
@@ -245,17 +245,15 @@ export interface MediaSidebarMedia {
     width?: number
     height?: number
   }
-  //TODO: Consistently fix the "Consider removing 'undefined' type or '?' specifier, one of them is redundant" issue
-  thumbnail?: SidebarMediaQueryQuery['media']['thumbnail'] | null
+  thumbnail?: NonNullable<SidebarMediaQueryQuery['media']['thumbnail']> | null
   videoWeb?: null | {
     __typename?: 'MediaURL'
     url: string
     width?: number
     height?: number
   }
-  //TODO: Consistently fix the "Consider removing 'undefined' type or '?' specifier, one of them is redundant" issue
-  videoMetadata?: SidebarMediaQueryQuery['media']['videoMetadata'] | null
-  exif?: SidebarMediaQueryQuery['media']['exif'] | null
+  videoMetadata?: NonNullable<SidebarMediaQueryQuery['media']['videoMetadata']> | null
+  exif?: NonNullable<SidebarMediaQueryQuery['media']['exif']> | null
   faces?: SidebarMediaQueryQuery['media']['faces']
   downloads?: SidebarDownloadQueryQuery['media']['downloads']
   album?: {

--- a/ui/src/components/sidebar/MediaSidebar/MediaSidebar.tsx
+++ b/ui/src/components/sidebar/MediaSidebar/MediaSidebar.tsx
@@ -245,6 +245,7 @@ export interface MediaSidebarMedia {
     width?: number
     height?: number
   }
+  //TODO: Consistently fix the "Consider removing 'undefined' type or '?' specifier, one of them is redundant" issue
   thumbnail?: SidebarMediaQueryQuery['media']['thumbnail'] | null
   videoWeb?: null | {
     __typename?: 'MediaURL'
@@ -252,6 +253,7 @@ export interface MediaSidebarMedia {
     width?: number
     height?: number
   }
+  //TODO: Consistently fix the "Consider removing 'undefined' type or '?' specifier, one of them is redundant" issue
   videoMetadata?: SidebarMediaQueryQuery['media']['videoMetadata'] | null
   exif?: SidebarMediaQueryQuery['media']['exif'] | null
   faces?: SidebarMediaQueryQuery['media']['faces']


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR refactors the merge-face-groups modal so it now exits early when closed, handles the missing-preselected-role case by logging an error and not rendering the modal, and moves the remaining modal UI into a dedicated content component. The close path now resets modal state immediately instead of relying on an effect, and the related test was updated to match the new behavior. It also tightens a few `MediaSidebarMedia` GraphQL field types to use non-nullable inner types for `thumbnail`, `videoMetadata`, and `exif`.

Benefits:
- Reduces the chance of stale modal state lingering after closure.
- Makes the modal’s invalid-state behavior more explicit and easier to reason about.
- Improves type safety in the media sidebar, which can prevent incorrect handling of GraphQL data.

Risks:
- The modal now depends more directly on the close flow for cleanup, so any missed close path could leave state uncleared.
- The new early-return behavior means users may see the modal disappear immediately in invalid states, which could affect error-reporting or debugging expectations.
- The stricter media typings may surface hidden assumptions in nearby UI code if those fields were previously treated as broader shapes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->