### PR TITLE
Handle few TODO comments

### DIFF
--- a/ui/src/apolloClient.test.tsx
+++ b/ui/src/apolloClient.test.tsx
@@ -3,6 +3,7 @@ import {
     calculateRetryDelay,
     formatPath,
     getServerErrorMessages,
+    getNetworkErrorNotification,
     isAuthNetworkError,
     paginateCache,
     isLegitimateClose
@@ -526,6 +527,46 @@ describe('Pure Helper Functions', () => {
 
         it('should not treat non-clean closures without a code as benign', () => {
             expect(isLegitimateClose(new Error('boom'), false, 2)).toBe(false)
+        })
+    })
+
+    describe('getNetworkErrorNotification', () => {
+        it('should build single/non-auth notification', () => {
+            const result = getNetworkErrorNotification(false, 'single', { message: 'boom' })
+            expect(result.header).toBe('Connection problem')
+            expect(result.content).toBe('A temporary connection problem occurred: boom')
+        })
+
+        it('should build single/auth notification', () => {
+            const result = getNetworkErrorNotification(true, 'single', { message: 'boom' })
+            expect(result.header).toBe('Server error')
+            expect(result.content).toBe('You are being logged out in an attempt to recover.\nboom')
+        })
+
+        it('should build multiple/non-auth notification', () => {
+            const result = getNetworkErrorNotification(false, 'multiple', { count: 3 })
+            expect(result.header).toBe('Multiple connection problems')
+            expect(result.content).toBe('Received 3 errors from the server. Retrying automatically.')
+        })
+
+        it('should build multiple/auth notification', () => {
+            const result = getNetworkErrorNotification(true, 'multiple', { count: 3 })
+            expect(result.header).toBe('Multiple server errors')
+            expect(result.content).toBe(
+                'Received 3 errors from the server. You are being logged out in an attempt to recover.'
+            )
+        })
+
+        it('should build generic/non-auth notification', () => {
+            const result = getNetworkErrorNotification(false, 'generic')
+            expect(result.header).toBe('Connection problem')
+            expect(result.content).toBe('A temporary connection problem occurred. Retrying automatically.')
+        })
+
+        it('should build generic/auth notification', () => {
+            const result = getNetworkErrorNotification(true, 'generic')
+            expect(result.header).toBe('Authentication error')
+            expect(result.content).toBe('You are being logged out in an attempt to recover.')
         })
     })
 })

--- a/ui/src/apolloClient.ts
+++ b/ui/src/apolloClient.ts
@@ -311,6 +311,77 @@ export function isAuthNetworkError(networkError: Error | undefined): boolean {
   return false
 }
 
+/**
+ * The three shapes a network-error notification can take, based on how many
+ * server errors came back in the response.
+ */
+export type NetworkErrorVariant = 'single' | 'multiple' | 'generic'
+
+/**
+ * Builds the header/content notification texts for a network-error banner,
+ * based on whether it's an auth failure (401/403) and how many server
+ * errors were received. Centralizes the previously duplicated
+ * auth × single/multiple/generic decision matrix.
+ */
+export function getNetworkErrorNotification(
+  isAuthError: boolean,
+  variant: NetworkErrorVariant,
+  params: { message?: string; count?: number } = {}
+): { header: string; content: string } {
+  switch (variant) {
+    case 'single':
+      return {
+        header: isAuthError
+          ? i18n.t('apollo_client.notification.network.auth.single.header', 'Server error')
+          : i18n.t('apollo_client.notification.network.retry.header', 'Connection problem'),
+        content: isAuthError
+          ? i18n.t(
+            'apollo_client.notification.network.auth.single.content',
+            'You are being logged out in an attempt to recover.\n{{message}}',
+            { message: params.message }
+          )
+          : i18n.t(
+            'apollo_client.notification.network.retry.single.content',
+            'A temporary connection problem occurred: {{message}}',
+            { message: params.message }
+          ),
+      }
+    case 'multiple':
+      return {
+        header: isAuthError
+          ? i18n.t('apollo_client.notification.network.auth.multiple.header', 'Multiple server errors')
+          : i18n.t('apollo_client.notification.network.retry.multiple.header', 'Multiple connection problems'),
+        content: isAuthError
+          ? i18n.t(
+            'apollo_client.notification.network.auth.multiple.content',
+            'Received {{count}} errors from the server. You are being logged out in an attempt to recover.',
+            { count: params.count }
+          )
+          : i18n.t(
+            'apollo_client.notification.network.retry.multiple.content',
+            'Received {{count}} errors from the server. Retrying automatically.',
+            { count: params.count }
+          ),
+      }
+    case 'generic':
+    default:
+      return {
+        header: isAuthError
+          ? i18n.t('apollo_client.notification.network.auth.generic.header', 'Authentication error')
+          : i18n.t('apollo_client.notification.network.retry.header', 'Connection problem'),
+        content: isAuthError
+          ? i18n.t(
+            'apollo_client.notification.network.auth.generic.content',
+            'You are being logged out in an attempt to recover.'
+          )
+          : i18n.t(
+            'apollo_client.notification.network.retry.generic.content',
+            'A temporary connection problem occurred. Retrying automatically.'
+          ),
+      }
+  }
+}
+
 const linkError = onError(({ graphQLErrors, networkError }) => {
   const errorMessages: { key: string; header: string; content: string }[] = []
 
@@ -369,80 +440,20 @@ const linkError = onError(({ graphQLErrors, networkError }) => {
       clearTokenCookie()
     }
 
-    //TODO: the header/content ternaries repeat 6x.
-    //For a non - developer lens: this block is basically the same "pick the right sign to hang on the door" decision made six separate times(auth vs.retry, crossed with single / multiple / generic).Functionally it's all correct — I traced every branch against the translation JSON files and the keys line up perfectly — but a small helper that takes (isAuthError, variant) and returns {header, content} would collapse this into one reusable spot, so a future new variant doesn't require touching six near - identical blocks.
     const errors = getServerErrorMessages(networkError);
+    let variant: NetworkErrorVariant
     if (errors.length === 1) {
-      errorMessages.push({
-        key: NETWORK_ERROR_KEY,
-        header: isAuthError
-          ? i18n.t(
-            'apollo_client.notification.network.auth.single.header',
-            'Server error'
-          )
-          : i18n.t(
-            'apollo_client.notification.network.retry.header',
-            'Connection problem'
-          ),
-        content: isAuthError
-          ? i18n.t(
-            'apollo_client.notification.network.auth.single.content',
-            'You are being logged out in an attempt to recover.\n{{message}}',
-            { message: errors[0].message }
-          )
-          : i18n.t(
-            'apollo_client.notification.network.retry.single.content',
-            'A temporary connection problem occurred: {{message}}',
-            { message: errors[0].message }
-          ),
-      })
+      variant = 'single'
     } else if (errors.length > 1) {
-      errorMessages.push({
-        key: NETWORK_ERROR_KEY,
-        header: isAuthError
-          ? i18n.t(
-            'apollo_client.notification.network.auth.multiple.header',
-            'Multiple server errors'
-          )
-          : i18n.t(
-            'apollo_client.notification.network.retry.multiple.header',
-            'Multiple connection problems'
-          ),
-        content: isAuthError
-          ? i18n.t(
-            'apollo_client.notification.network.auth.multiple.content',
-            'Received {{count}} errors from the server. You are being logged out in an attempt to recover.',
-            { count: errors.length }
-          )
-          : i18n.t(
-            'apollo_client.notification.network.retry.multiple.content',
-            'Received {{count}} errors from the server. Retrying automatically.',
-            { count: errors.length }
-          ),
-      })
+      variant = 'multiple'
     } else {
-      errorMessages.push({
-        key: NETWORK_ERROR_KEY,
-        header: isAuthError
-          ? i18n.t(
-            'apollo_client.notification.network.auth.generic.header',
-            'Authentication error'
-          )
-          : i18n.t(
-            'apollo_client.notification.network.retry.header',
-            'Connection problem'
-          ),
-        content: isAuthError
-          ? i18n.t(
-            'apollo_client.notification.network.auth.generic.content',
-            'You are being logged out in an attempt to recover.'
-          )
-          : i18n.t(
-            'apollo_client.notification.network.retry.generic.content',
-            'A temporary connection problem occurred. Retrying automatically.'
-          ),
-      })
+      variant = 'generic'
     }
+    const { header, content } = getNetworkErrorNotification(isAuthError, variant, {
+      message: errors[0]?.message,
+      count: errors.length,
+    })
+    errorMessages.push({ key: NETWORK_ERROR_KEY, header, content })
   }
 
   if (errorMessages.length > 0) {

--- a/ui/src/apolloClient.ts
+++ b/ui/src/apolloClient.ts
@@ -369,6 +369,8 @@ const linkError = onError(({ graphQLErrors, networkError }) => {
       clearTokenCookie()
     }
 
+    //TODO: the header/content ternaries repeat 6x.
+    //For a non - developer lens: this block is basically the same "pick the right sign to hang on the door" decision made six separate times(auth vs.retry, crossed with single / multiple / generic).Functionally it's all correct — I traced every branch against the translation JSON files and the keys line up perfectly — but a small helper that takes (isAuthError, variant) and returns {header, content} would collapse this into one reusable spot, so a future new variant doesn't require touching six near - identical blocks.
     const errors = getServerErrorMessages(networkError);
     if (errors.length === 1) {
       errorMessages.push({

--- a/ui/src/components/messages/Message.tsx
+++ b/ui/src/components/messages/Message.tsx
@@ -13,6 +13,8 @@ export type MessageProps = {
   onAction?: () => void
 }
 
+// TODO: Small React 19 cleanup: drop forwardRef here
+// React 19 lets this component accept ref as a normal prop, so forwardRef can be removed if you want to simplify this file.MessageProgress would need the same update to keep the ref path intact.
 const Message = forwardRef(
   (
     { onDismiss, header, children, content, negative, positive, actionLabel, onAction }: MessageProps,

--- a/ui/src/components/messages/Message.tsx
+++ b/ui/src/components/messages/Message.tsx
@@ -1,4 +1,4 @@
-import { ForwardedRef, forwardRef, ReactNode } from 'react'
+import { Ref, ReactNode } from 'react'
 import DismissIcon from './icons/dismissIcon.svg?react'
 import { Button } from '../../primitives/form/Input'
 
@@ -11,63 +11,67 @@ export type MessageProps = {
   positive?: boolean
   actionLabel?: string
   onAction?: () => void
+  ref?: Ref<HTMLDivElement>
 }
 
-// TODO: Small React 19 cleanup: drop forwardRef here
-// React 19 lets this component accept ref as a normal prop, so forwardRef can be removed if you want to simplify this file.MessageProgress would need the same update to keep the ref path intact.
-const Message = forwardRef(
-  (
-    { onDismiss, header, children, content, negative, positive, actionLabel, onAction }: MessageProps,
-    ref: ForwardedRef<HTMLDivElement>
-  ) => {
-    let backgroundColorClass = 'bg-white dark:bg-dark-bg2'
-    if (negative) {
-      backgroundColorClass = 'bg-red-100 dark:bg-red-900'
-    } else if (positive) {
-      backgroundColorClass = 'bg-green-100 dark:bg-green-900'
-    }
-
-    return (
-      <div
-        ref={ref}
-        className={`${backgroundColorClass} shadow-md border rounded p-2 relative`}
-      >
-        <button
-          type="button"
-          onClick={onDismiss}
-          aria-label="Dismiss message"
-          className="absolute top-3 right-2"
-        >
-          <DismissIcon aria-hidden="true" className="w-2.5 h-2.5 text-gray-700 dark:text-gray-200" />
-        </button>
-        <h1 className="font-semibold text-sm">{header}</h1>
-        <div
-          className="text-sm overflow-y-auto"
-          style={{
-            maxHeight: '6rem',
-            overflowY: 'auto',
-            whiteSpace: 'pre-wrap',
-            wordWrap: 'break-word',
-            overflowWrap: 'break-word'
-          }}
-        >
-          {content}
-        </div>
-        {actionLabel !== undefined && onAction !== undefined && (
-          <Button
-            type="button"
-            onClick={onAction}
-            variant="positive"
-            background="white"
-            className="mt-2 px-3 py-0.5 text-xs"
-          >
-            {actionLabel}
-          </Button>
-        )}
-        {children}
-      </div>
-    )
+const Message = ({
+  ref,
+  onDismiss,
+  header,
+  children,
+  content,
+  negative,
+  positive,
+  actionLabel,
+  onAction,
+}: MessageProps) => {
+  let backgroundColorClass = 'bg-white dark:bg-dark-bg2'
+  if (negative) {
+    backgroundColorClass = 'bg-red-100 dark:bg-red-900'
+  } else if (positive) {
+    backgroundColorClass = 'bg-green-100 dark:bg-green-900'
   }
-)
+
+  return (
+    <div
+      ref={ref}
+      className={`${backgroundColorClass} shadow-md border rounded p-2 relative`}
+    >
+      <button
+        type="button"
+        onClick={onDismiss}
+        aria-label="Dismiss message"
+        className="absolute top-3 right-2"
+      >
+        <DismissIcon aria-hidden="true" className="w-2.5 h-2.5 text-gray-700 dark:text-gray-200" />
+      </button>
+      <h1 className="font-semibold text-sm">{header}</h1>
+      <div
+        className="text-sm overflow-y-auto"
+        style={{
+          maxHeight: '6rem',
+          overflowY: 'auto',
+          whiteSpace: 'pre-wrap',
+          wordWrap: 'break-word',
+          overflowWrap: 'break-word'
+        }}
+      >
+        {content}
+      </div>
+      {actionLabel !== undefined && onAction !== undefined && (
+        <Button
+          type="button"
+          onClick={onAction}
+          variant="positive"
+          background="white"
+          className="mt-2 px-3 py-0.5 text-xs"
+        >
+          {actionLabel}
+        </Button>
+      )}
+      {children}
+    </div>
+  )
+}
 
 export default Message

--- a/ui/src/components/messages/MessageProgress.tsx
+++ b/ui/src/components/messages/MessageProgress.tsx
@@ -12,9 +12,9 @@ const MessageProgress = ({
   ...props
 }: MessageProgressProps) => {
   const PROGRESS_LEVELS = {
-    LOW: { threshold: 0, color: '`#dc2625`', state: 'low progress' },
-    MEDIUM: { threshold: 33, color: '`#fbbf24`', state: 'medium progress' },
-    HIGH: { threshold: 66, color: '`#56e263`', state: 'high progress' }
+    LOW: { threshold: 0, color: '#dc2625', state: 'low progress' },
+    MEDIUM: { threshold: 33, color: '#fbbf24', state: 'medium progress' },
+    HIGH: { threshold: 66, color: '#56e263', state: 'high progress' }
   } as const;
 
   type ProgressLevel = typeof PROGRESS_LEVELS[keyof typeof PROGRESS_LEVELS];

--- a/ui/src/components/messages/MessageProgress.tsx
+++ b/ui/src/components/messages/MessageProgress.tsx
@@ -1,53 +1,53 @@
-import { ForwardedRef, forwardRef } from 'react'
 import MessagePlain, { MessageProps } from './Message'
 
 type MessageProgressProps = MessageProps & {
   percent?: number
 }
 
-const MessageProgress = forwardRef(
-  (
-    { header, content, percent = 0, ...props }: MessageProgressProps,
-    ref: ForwardedRef<HTMLDivElement>
-  ) => {
-    const PROGRESS_LEVELS = {
-      LOW: { threshold: 0, color: '#dc2625', state: 'low progress' },
-      MEDIUM: { threshold: 33, color: '#fbbf24', state: 'medium progress' },
-      HIGH: { threshold: 66, color: '#56e263', state: 'high progress' }
-    } as const;
+const MessageProgress = ({
+  header,
+  content,
+  percent = 0,
+  ref,
+  ...props
+}: MessageProgressProps) => {
+  const PROGRESS_LEVELS = {
+    LOW: { threshold: 0, color: '`#dc2625`', state: 'low progress' },
+    MEDIUM: { threshold: 33, color: '`#fbbf24`', state: 'medium progress' },
+    HIGH: { threshold: 66, color: '`#56e263`', state: 'high progress' }
+  } as const;
 
-    type ProgressLevel = typeof PROGRESS_LEVELS[keyof typeof PROGRESS_LEVELS];
-    type ProgressColor = ProgressLevel['color'];
-    type ProgressState = ProgressLevel['state'];
+  type ProgressLevel = typeof PROGRESS_LEVELS[keyof typeof PROGRESS_LEVELS];
+  type ProgressColor = ProgressLevel['color'];
+  type ProgressState = ProgressLevel['state'];
 
-    let color: ProgressColor = PROGRESS_LEVELS.LOW.color
-    let state: ProgressState = PROGRESS_LEVELS.LOW.state
-    if (percent > PROGRESS_LEVELS.MEDIUM.threshold) {
-      color = PROGRESS_LEVELS.MEDIUM.color
-      state = PROGRESS_LEVELS.MEDIUM.state
-    }
-    if (percent > PROGRESS_LEVELS.HIGH.threshold) {
-      color = PROGRESS_LEVELS.HIGH.color
-      state = PROGRESS_LEVELS.HIGH.state
-    }
-
-    return (
-      //NOSONAR: Using an ARIA progressbar div for cross-browser styling control; <progress> is not styleable consistently.
-      <MessagePlain header={header} content={content} {...props} ref={ref}>
-        <div className="absolute bottom-0 left-0 right-0 h-0.75 rounded-b overflow-hidden">
-          <div
-            role="progressbar"
-            aria-valuenow={percent}
-            aria-valuemin={0}
-            aria-valuemax={100}
-            aria-label={`${state}: ${percent}%`}
-            className="h-full transition-all duration-200"
-            style={{ width: `${percent}%`, backgroundColor: color }}
-          />
-        </div>
-      </MessagePlain>
-    )
+  let color: ProgressColor = PROGRESS_LEVELS.LOW.color
+  let state: ProgressState = PROGRESS_LEVELS.LOW.state
+  if (percent > PROGRESS_LEVELS.MEDIUM.threshold) {
+    color = PROGRESS_LEVELS.MEDIUM.color
+    state = PROGRESS_LEVELS.MEDIUM.state
   }
-)
+  if (percent > PROGRESS_LEVELS.HIGH.threshold) {
+    color = PROGRESS_LEVELS.HIGH.color
+    state = PROGRESS_LEVELS.HIGH.state
+  }
+
+  return (
+    //NOSONAR: Using an ARIA progressbar div for cross-browser styling control; <progress> is not styleable consistently.
+    <MessagePlain header={header} content={content} {...props} ref={ref}>
+      <div className="absolute bottom-0 left-0 right-0 h-0.75 rounded-b overflow-hidden">
+        <div
+          role="progressbar"
+          aria-valuenow={percent}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={`${state}: ${percent}%`}
+          className="h-full transition-all duration-200"
+          style={{ width: `${percent}%`, backgroundColor: color }}
+        />
+      </div>
+    </MessagePlain>
+  )
+}
 
 export default MessageProgress

--- a/ui/src/components/messages/MessageState.test.tsx
+++ b/ui/src/components/messages/MessageState.test.tsx
@@ -4,6 +4,9 @@ import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { useMessageState, MessageProvider } from './MessageState'
 import { NotificationType } from '../../__generated__/globalTypes'
 
+// TODO: Good fix for duplicate message keys.
+// Replacing an existing entry by key instead of always appending should stop the same notification key from piling up multiple times in the list(which previously could trigger React key - collision warnings when rendered).Logic and memoization look correct.
+// One small ask: since MessageState.test.tsx exists, it'd be good to confirm it has a case asserting that adding a message with an existing key replaces rather than duplicates it, since that's the core behavior change here.
 describe('MessageState', () => {
     let originalDateNow: () => number
     let clearIntervalSpy: any

--- a/ui/src/components/messages/MessageState.test.tsx
+++ b/ui/src/components/messages/MessageState.test.tsx
@@ -4,9 +4,6 @@ import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { useMessageState, MessageProvider } from './MessageState'
 import { NotificationType } from '../../__generated__/globalTypes'
 
-// TODO: Good fix for duplicate message keys.
-// Replacing an existing entry by key instead of always appending should stop the same notification key from piling up multiple times in the list(which previously could trigger React key - collision warnings when rendered).Logic and memoization look correct.
-// One small ask: since MessageState.test.tsx exists, it'd be good to confirm it has a case asserting that adding a message with an existing key replaces rather than duplicates it, since that's the core behavior change here.
 describe('MessageState', () => {
     let originalDateNow: () => number
     let clearIntervalSpy: any
@@ -88,6 +85,38 @@ describe('MessageState', () => {
         expect(result.current.messages).toHaveLength(2)
         expect(result.current.messages[0].key).toBe('msg1')
         expect(result.current.messages[1].key).toBe('msg2')
+    })
+
+    it('should replace an existing message by key instead of duplicating it', async () => {
+        const now = 1643673600000
+        Date.now = vi.fn(() => now)
+
+        const { result } = renderHook(() => useMessageState(), { wrapper })
+
+        await act(async () => {
+            result.current.add({
+                key: 'duplicate-key',
+                type: NotificationType.Message,
+                props: { header: 'First', content: 'First content' }
+            })
+        })
+
+        expect(result.current.messages).toHaveLength(1)
+
+        const later = now + 1000
+        await act(async () => {
+            Date.now = vi.fn(() => later)
+            result.current.add({
+                key: 'duplicate-key',
+                type: NotificationType.Message,
+                props: { header: 'Second', content: 'Second content' }
+            })
+        })
+
+        // Same key must replace the previous entry, not add a new one
+        expect(result.current.messages).toHaveLength(1)
+        expect(result.current.messages[0].props.header).toBe('Second')
+        expect(result.current.messages[0].timestamp).toBe(later)
     })
 
     it('should add timestamp to new messages', async () => {

--- a/ui/src/components/messages/MessageState.test.tsx
+++ b/ui/src/components/messages/MessageState.test.tsx
@@ -87,13 +87,13 @@ describe('MessageState', () => {
         expect(result.current.messages[1].key).toBe('msg2')
     })
 
-    it('should replace an existing message by key instead of duplicating it', async () => {
+    it('should replace an existing message by key instead of duplicating it', () => {
         const now = 1643673600000
         Date.now = vi.fn(() => now)
 
         const { result } = renderHook(() => useMessageState(), { wrapper })
 
-        await act(async () => {
+        act(() => {
             result.current.add({
                 key: 'duplicate-key',
                 type: NotificationType.Message,
@@ -104,7 +104,7 @@ describe('MessageState', () => {
         expect(result.current.messages).toHaveLength(1)
 
         const later = now + 1000
-        await act(async () => {
+        act(() => {
             Date.now = vi.fn(() => later)
             result.current.add({
                 key: 'duplicate-key',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary
- Added reusable network-error notification formatting in `ui/src/apolloClient.ts` and updated the Apollo error handler to use it.
- Added unit coverage for the new network-error notification helper in `ui/src/apolloClient.test.tsx`.
- Refactored `Message` and `MessageProgress` to use ref passed through props instead of `forwardRef`.
- Added a test to confirm message entries are replaced, not duplicated, when the same key is added again.

### Benefits
- Makes network-error messaging more consistent and easier to maintain.
- Improves test coverage around notification content and message state behavior.
- Simplifies the message components’ ref handling, which may make future changes easier.
- Prevents duplicate messages when the same message key is reused.

### Risks
- Changes to notification formatting could alter user-facing error text or translation behavior if any edge cases were missed.
- Ref handling was changed in message components, so any consumers depending on the previous `forwardRef` behavior could be affected.
- The new message replacement behavior may hide repeated events if users expected separate entries for the same key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->