### PR TITLE
Finish the GQLgen migration to the new Websocket library

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/gorilla/handlers v1.5.2
 	github.com/gorilla/mux v1.8.1
-	github.com/gorilla/websocket v1.5.3
 	github.com/joho/godotenv v1.5.1
 	github.com/otiai10/copy v1.14.1
 	github.com/pkg/errors v0.9.1

--- a/api/go.sum
+++ b/api/go.sum
@@ -33,8 +33,6 @@ github.com/gorilla/handlers v1.5.2 h1:cLTUSsNkgcwhgRqvCNmdbRWG0A3N4F+M2nWKdScwyE
 github.com/gorilla/handlers v1.5.2/go.mod h1:dX+xVpaxdSw+q0Qek8SSsl3dfMk3jNddUkMzo0GtH0w=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
-github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
-github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=

--- a/api/server/websocket.go
+++ b/api/server/websocket.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/99designs/gqlgen/graphql/handler/transport"
 	coderws "github.com/coder/websocket"
-	"github.com/gorilla/websocket"
 	"github.com/kkovaletp/photoview/api/utils"
 )
 
@@ -38,12 +37,6 @@ func (w websocketImplementation) Accept(rw http.ResponseWriter, r *http.Request,
 	}
 
 	return w.accept.Accept(rw, r, options)
-}
-
-func WebsocketUpgrader(devMode bool) websocket.Upgrader {
-	return websocket.Upgrader{
-		CheckOrigin: websocketCheckOrigin(devMode),
-	}
 }
 
 func websocketCheckOrigin(devMode bool) func(r *http.Request) bool {

--- a/api/server/websocket_test.go
+++ b/api/server/websocket_test.go
@@ -51,21 +51,23 @@ func configureTestEndpointsFromEnv(t *testing.T) {
 
 					switch scheme {
 					case "http":
-						if port == "" {
+						switch port {
+						case "":
 							// Add variant with explicit port 80
 							withPort, _ := url.Parse("http://" + host + ":80")
 							uiEndpoints = append(uiEndpoints, withPort)
-						} else if port == "80" {
+						case "80":
 							// Add variant without port
 							withoutPort, _ := url.Parse("http://" + host)
 							uiEndpoints = append(uiEndpoints, withoutPort)
 						}
 					case "https":
-						if port == "" {
+						switch port {
+						case "":
 							// Add variant with explicit port 443
 							withPort, _ := url.Parse("https://" + host + ":443")
 							uiEndpoints = append(uiEndpoints, withPort)
-						} else if port == "443" {
+						case "443":
 							// Add variant without port
 							withoutPort, _ := url.Parse("https://" + host)
 							uiEndpoints = append(uiEndpoints, withoutPort)
@@ -85,11 +87,11 @@ func configureTestEndpointsFromEnv(t *testing.T) {
 }
 
 // =============================================================================
-// WebsocketUpgrader CheckOrigin Tests
+// websocketCheckOrigin Tests
 // =============================================================================
 
-func TestWebsocketUpgraderDevModeAllowsAllOrigins(t *testing.T) {
-	upgrader := WebsocketUpgrader(true)
+func TestWebsocketCheckOriginDevModeAllowsAllOrigins(t *testing.T) {
+	checkOrigin := websocketCheckOrigin(true)
 
 	testCases := []struct {
 		name   string
@@ -108,17 +110,17 @@ func TestWebsocketUpgraderDevModeAllowsAllOrigins(t *testing.T) {
 				req.Header.Set("Origin", tc.origin)
 			}
 
-			result := upgrader.CheckOrigin(req)
+			result := checkOrigin(req)
 			assert.True(t, result, "DevMode should allow all origins")
 		})
 	}
 }
 
-func TestWebsocketUpgraderShouldServeUIAllowsAllOrigins(t *testing.T) {
+func TestWebsocketCheckOriginShouldServeUIAllowsAllOrigins(t *testing.T) {
 	t.Setenv("PHOTOVIEW_SERVE_UI", "1")
 	configureTestEndpointsFromEnv(t)
 
-	upgrader := WebsocketUpgrader(false)
+	checkOrigin := websocketCheckOrigin(false)
 
 	testCases := []struct {
 		name   string
@@ -136,52 +138,52 @@ func TestWebsocketUpgraderShouldServeUIAllowsAllOrigins(t *testing.T) {
 				req.Header.Set("Origin", tc.origin)
 			}
 
-			result := upgrader.CheckOrigin(req)
+			result := checkOrigin(req)
 			assert.True(t, result, "When serving UI internally, should allow all origins")
 		})
 	}
 }
 
-func TestWebsocketUpgraderEmptyOriginAllowed(t *testing.T) {
+func TestWebsocketCheckOriginEmptyOriginAllowed(t *testing.T) {
 	t.Setenv("PHOTOVIEW_SERVE_UI", "0")
 	t.Setenv("PHOTOVIEW_UI_ENDPOINTS", "https://ui.example.com")
 	configureTestEndpointsFromEnv(t)
 
-	upgrader := WebsocketUpgrader(false)
+	checkOrigin := websocketCheckOrigin(false)
 	req := httptest.NewRequest("GET", "/ws", nil)
 	// Explicitly not setting Origin header
 
-	result := upgrader.CheckOrigin(req)
+	result := checkOrigin(req)
 	assert.True(t, result, "Empty origin header should be allowed")
 }
 
-func TestWebsocketUpgraderInvalidOriginRejected(t *testing.T) {
+func TestWebsocketCheckOriginInvalidOriginRejected(t *testing.T) {
 	t.Setenv("PHOTOVIEW_SERVE_UI", "0")
 	t.Setenv("PHOTOVIEW_UI_ENDPOINTS", "https://ui.example.com")
 	configureTestEndpointsFromEnv(t)
 
-	upgrader := WebsocketUpgrader(false)
+	checkOrigin := websocketCheckOrigin(false)
 	req := httptest.NewRequest("GET", "/ws", nil)
 	req.Header.Set("Origin", "://invalid-url")
 
-	result := upgrader.CheckOrigin(req)
+	result := checkOrigin(req)
 	assert.False(t, result, "Invalid origin URL should be rejected")
 }
 
-func TestWebsocketUpgraderMatchingSingleEndpointAllowed(t *testing.T) {
+func TestWebsocketCheckOriginMatchingSingleEndpointAllowed(t *testing.T) {
 	t.Setenv("PHOTOVIEW_SERVE_UI", "0")
 	t.Setenv("PHOTOVIEW_UI_ENDPOINTS", "https://ui.example.com")
 	configureTestEndpointsFromEnv(t)
 
-	upgrader := WebsocketUpgrader(false)
+	checkOrigin := websocketCheckOrigin(false)
 	req := httptest.NewRequest("GET", "/ws", nil)
 	req.Header.Set("Origin", "https://ui.example.com")
 
-	result := upgrader.CheckOrigin(req)
+	result := checkOrigin(req)
 	assert.True(t, result, "Origin matching configured UI endpoint should be allowed")
 }
 
-func TestWebsocketUpgraderMatchingMultipleEndpoints(t *testing.T) {
+func TestWebsocketCheckOriginMatchingMultipleEndpoints(t *testing.T) {
 	t.Setenv("PHOTOVIEW_SERVE_UI", "0")
 	t.Setenv("PHOTOVIEW_UI_ENDPOINTS", "https://ui1.example.com,https://ui2.example.com,https://ui3.example.com")
 	configureTestEndpointsFromEnv(t)
@@ -200,18 +202,18 @@ func TestWebsocketUpgraderMatchingMultipleEndpoints(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			upgrader := WebsocketUpgrader(false)
+			checkOrigin := websocketCheckOrigin(false)
 			req := httptest.NewRequest("GET", "/ws", nil)
 			req.Header.Set("Origin", tc.origin)
 
-			result := upgrader.CheckOrigin(req)
+			result := checkOrigin(req)
 			assert.Equal(t, tc.shouldBeAllowed, result,
 				"Origin %s should be %v", tc.origin, tc.shouldBeAllowed)
 		})
 	}
 }
 
-func TestWebsocketUpgraderNonMatchingOriginRejected(t *testing.T) {
+func TestWebsocketCheckOriginNonMatchingOriginRejected(t *testing.T) {
 	t.Setenv("PHOTOVIEW_SERVE_UI", "0")
 	t.Setenv("PHOTOVIEW_UI_ENDPOINTS", "https://ui.example.com")
 	configureTestEndpointsFromEnv(t)
@@ -228,17 +230,17 @@ func TestWebsocketUpgraderNonMatchingOriginRejected(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			upgrader := WebsocketUpgrader(false)
+			checkOrigin := websocketCheckOrigin(false)
 			req := httptest.NewRequest("GET", "/ws", nil)
 			req.Header.Set("Origin", tc.origin)
 
-			result := upgrader.CheckOrigin(req)
+			result := checkOrigin(req)
 			assert.False(t, result, "Origin %s should be rejected", tc.origin)
 		})
 	}
 }
 
-func TestWebsocketUpgraderPortMatching(t *testing.T) {
+func TestWebsocketCheckOriginPortMatching(t *testing.T) {
 	t.Setenv("PHOTOVIEW_SERVE_UI", "0")
 	t.Setenv("PHOTOVIEW_UI_ENDPOINTS", "https://ui.example.com:8443")
 	configureTestEndpointsFromEnv(t)
@@ -255,18 +257,18 @@ func TestWebsocketUpgraderPortMatching(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			upgrader := WebsocketUpgrader(false)
+			checkOrigin := websocketCheckOrigin(false)
 			req := httptest.NewRequest("GET", "/ws", nil)
 			req.Header.Set("Origin", tc.origin)
 
-			result := upgrader.CheckOrigin(req)
+			result := checkOrigin(req)
 			assert.Equal(t, tc.shouldBeAllowed, result,
 				"Origin %s should be %v", tc.origin, tc.shouldBeAllowed)
 		})
 	}
 }
 
-func TestWebsocketUpgraderWhitespaceInEndpoints(t *testing.T) {
+func TestWebsocketCheckOriginWhitespaceInEndpoints(t *testing.T) {
 	t.Setenv("PHOTOVIEW_SERVE_UI", "0")
 	t.Setenv("PHOTOVIEW_UI_ENDPOINTS", " https://ui1.example.com , https://ui2.example.com , https://ui3.example.com ")
 	configureTestEndpointsFromEnv(t)
@@ -279,17 +281,17 @@ func TestWebsocketUpgraderWhitespaceInEndpoints(t *testing.T) {
 
 	for _, origin := range testCases {
 		t.Run(origin, func(t *testing.T) {
-			upgrader := WebsocketUpgrader(false)
+			checkOrigin := websocketCheckOrigin(false)
 			req := httptest.NewRequest("GET", "/ws", nil)
 			req.Header.Set("Origin", origin)
 
-			result := upgrader.CheckOrigin(req)
+			result := checkOrigin(req)
 			assert.True(t, result, "Should handle whitespace in endpoint list")
 		})
 	}
 }
 
-func TestWebsocketUpgraderCaseInsensitiveHostMatching(t *testing.T) {
+func TestWebsocketCheckOriginCaseInsensitiveHostMatching(t *testing.T) {
 	t.Setenv("PHOTOVIEW_SERVE_UI", "0")
 	t.Setenv("PHOTOVIEW_UI_ENDPOINTS", "https://UI.EXAMPLE.COM")
 	configureTestEndpointsFromEnv(t)
@@ -306,18 +308,18 @@ func TestWebsocketUpgraderCaseInsensitiveHostMatching(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			upgrader := WebsocketUpgrader(false)
+			checkOrigin := websocketCheckOrigin(false)
 			req := httptest.NewRequest("GET", "/ws", nil)
 			req.Header.Set("Origin", tc.origin)
 
-			result := upgrader.CheckOrigin(req)
+			result := checkOrigin(req)
 			assert.Equal(t, tc.shouldBeAllowed, result,
 				"Host matching should be case-insensitive per URL spec")
 		})
 	}
 }
 
-func TestWebsocketUpgraderSanitizationOfMaliciousOrigin(t *testing.T) {
+func TestWebsocketCheckOriginSanitizationOfMaliciousOrigin(t *testing.T) {
 	t.Setenv("PHOTOVIEW_SERVE_UI", "0")
 	t.Setenv("PHOTOVIEW_UI_ENDPOINTS", "https://ui.example.com")
 	configureTestEndpointsFromEnv(t)
@@ -333,18 +335,18 @@ func TestWebsocketUpgraderSanitizationOfMaliciousOrigin(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			upgrader := WebsocketUpgrader(false)
+			checkOrigin := websocketCheckOrigin(false)
 			req := httptest.NewRequest("GET", "/ws", nil)
 			req.Header.Set("Origin", tc.origin)
 
-			result := upgrader.CheckOrigin(req)
+			result := checkOrigin(req)
 			assert.False(t, result, "Malicious origin should be rejected")
 			// The test passes if it doesn't panic and properly sanitizes the log output
 		})
 	}
 }
 
-func TestWebsocketUpgraderIPv6Endpoints(t *testing.T) {
+func TestWebsocketCheckOriginIPv6Endpoints(t *testing.T) {
 	t.Setenv("PHOTOVIEW_SERVE_UI", "0")
 	t.Setenv("PHOTOVIEW_UI_ENDPOINTS", "https://[::1]:8080,https://[2001:db8::1]:443")
 	configureTestEndpointsFromEnv(t)
@@ -362,18 +364,18 @@ func TestWebsocketUpgraderIPv6Endpoints(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			upgrader := WebsocketUpgrader(false)
+			checkOrigin := websocketCheckOrigin(false)
 			req := httptest.NewRequest("GET", "/ws", nil)
 			req.Header.Set("Origin", tc.origin)
 
-			result := upgrader.CheckOrigin(req)
+			result := checkOrigin(req)
 			assert.Equal(t, tc.shouldBeAllowed, result,
 				"IPv6 origin %s should be %v", tc.origin, tc.shouldBeAllowed)
 		})
 	}
 }
 
-func TestWebsocketUpgraderPathsDoNotAffectMatching(t *testing.T) {
+func TestWebsocketCheckOriginPathsDoNotAffectMatching(t *testing.T) {
 	t.Setenv("PHOTOVIEW_SERVE_UI", "0")
 	t.Setenv("PHOTOVIEW_UI_ENDPOINTS", "https://ui.example.com")
 	configureTestEndpointsFromEnv(t)
@@ -390,11 +392,11 @@ func TestWebsocketUpgraderPathsDoNotAffectMatching(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			upgrader := WebsocketUpgrader(false)
+			checkOrigin := websocketCheckOrigin(false)
 			req := httptest.NewRequest("GET", "/ws", nil)
 			req.Header.Set("Origin", tc.origin)
 
-			result := upgrader.CheckOrigin(req)
+			result := checkOrigin(req)
 			assert.True(t, result, "Path/query/fragment should not affect host matching")
 		})
 	}


### PR DESCRIPTION
Fixes #1039 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Finished the gqlgen websocket migration by wiring websocket origin validation through gqlgen’s `transport.CoderWebsocketImplementation.checkOrigin` hook.
- Removed the Gorilla-specific `WebsocketUpgrader` helper and eliminated the direct `github.com/gorilla/websocket` dependency.
- Preserved the existing websocket origin policy: allow all origins in development mode, allow requests when the UI is served by the API, allow empty `Origin` headers, and otherwise allow only configured `PHOTOVIEW_UI_ENDPOINTS` origins (with safe, sanitized logging and rejection of malformed/non-matching origins).
- Refocused tests to validate the shared `websocketCheckOrigin` policy directly (instead of a transport/upgrader-specific check), keeping coverage for whitespace, case-insensitive host matching, IPv6, and malicious `Origin` handling.

## Product benefits

- Keeps websocket behavior consistent with the current gqlgen websocket API, reducing integration brittleness.
- Removes obsolete websocket integration code/dependency, lowering maintenance effort and simplifying future upgrades.
- Maintains the same origin-safety guarantees for browser clients, helping prevent unintended websocket connections.

## Product risks

- If there are any legacy clients that relied on the old Gorilla upgrader behavior (even subtly), they may fail to connect due to stricter or differently-evaluated origin checks.
- Any regression in origin parsing/normalization could either:
  - block legitimate browser connections from the UI, or
  - unintentionally accept origins that should be rejected—so the configured UI endpoint and malformed/edge-case `Origin` scenarios are critical to validate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->