### PR TITLE
Define the `graphql-codegen` group for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,6 +42,9 @@ updates:
       vitest:
         patterns:
           - "*vitest*"
+      graphql-codegen:
+        patterns:
+          - "@graphql-codegen/*"
 
   # Maintain dependencies for Dockerfiles
   - package-ecosystem: "docker"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Added a Dependabot `graphql-codegen` group for npm dependencies matching `@graphql-codegen/*`.
- GraphQL Code Generator packages will now be proposed together in a single update.

## Product benefits
- Keeps related code-generation tooling synchronized, reducing the chance of incompatible package versions.
- Simplifies dependency maintenance and review.

## Product risks
- Grouped updates may introduce several dependency changes at once, increasing the scope of testing needed before merging.
- A problematic update could affect generated GraphQL code or related build workflows until the grouped update is reviewed and validated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->