### PR TITLE
Fix the version commit in the Settings page

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -146,7 +146,6 @@ COPY --from=ui /app/ui/dist "${PHOTOVIEW_UI_PATH}"
 # This is a w/a for letting the UI build stage to be cached
 # and not rebuilt every new commit because of the build_arg value change.
 ARG COMMIT_SHA=NoCommit
-# how to fix the `find` command to not hardcode the page name? (SettingsPage.*.js) - maybe use a regex to find the file that contains the placeholder string instead of hardcoding the page name.
 RUN find "${PHOTOVIEW_UI_PATH}/assets" -type f \( -name "*.js" -o -name "*.mjs" \) \
         -exec grep -qF -- '"-=<GitHub-CI-commit-sha-placeholder>=-"' {} \; \
         -exec sed -i 's/"-=<GitHub-CI-commit-sha-placeholder>=-"/"'"${COMMIT_SHA}"'"/g' {} \; \
@@ -216,7 +215,7 @@ ARG COMMIT_SHA=NoCommit
 # hadolint ignore=DL3018
 RUN apk add --no-cache curl bash \
     && apk add --no-cache --virtual .build-compress gzip brotli zstd \
-    RUN find "${PHOTOVIEW_UI_PATH}/assets" -type f \( -name "*.js" -o -name "*.mjs" \) \
+    && find /srv/assets -type f \( -name "*.js" -o -name "*.mjs" \) \
         -exec grep -qF -- '"-=<GitHub-CI-commit-sha-placeholder>=-"' {} \; \
         -exec sed -i 's/"-=<GitHub-CI-commit-sha-placeholder>=-"/"'"${COMMIT_SHA}"'"/g' {} \; \
     # Archive static files for better performance

--- a/Dockerfile
+++ b/Dockerfile
@@ -145,6 +145,7 @@ COPY --from=ui /app/ui/dist "${PHOTOVIEW_UI_PATH}"
 # This is a w/a for letting the UI build stage to be cached
 # and not rebuilt every new commit because of the build_arg value change.
 ARG COMMIT_SHA=NoCommit
+# how to fix the `find` command to not hardcode the page name? (SettingsPage.*.js) - maybe use a regex to find the file that contains the placeholder string instead of hardcoding the page name.
 RUN find "${PHOTOVIEW_UI_PATH}/assets" -type f -name "SettingsPage.*.js" \
         -exec sed -i 's/"-=<GitHub-CI-commit-sha-placeholder>=-"/"'"${COMMIT_SHA}"'"/g' {} \; \
     # Archive static files for better performance

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,9 @@ ENV NODE_ENV=${NODE_ENV}
 WORKDIR /app/ui
 
 COPY ui/package.json ui/package-lock.json /app/ui/
+# The NPM installation package contains important scripts, so using `--ignore-scripts` is not an option.
 # hadolint ignore=DL3016
-RUN npm install --global npm \
+RUN npm install --global npm --no-audit --no-fund \
     # Project dependencies with install scripts (esbuild,core-js) are required for the build.
     # Using `--ignore-scripts` is not an option.
     && if [ "$NODE_ENV" = "production" ]; then \
@@ -146,7 +147,8 @@ COPY --from=ui /app/ui/dist "${PHOTOVIEW_UI_PATH}"
 # and not rebuilt every new commit because of the build_arg value change.
 ARG COMMIT_SHA=NoCommit
 # how to fix the `find` command to not hardcode the page name? (SettingsPage.*.js) - maybe use a regex to find the file that contains the placeholder string instead of hardcoding the page name.
-RUN find "${PHOTOVIEW_UI_PATH}/assets" -type f -name "SettingsPage.*.js" \
+RUN find "${PHOTOVIEW_UI_PATH}/assets" -type f \( -name "*.js" -o -name "*.mjs" \) \
+        -exec grep -qF -- '"-=<GitHub-CI-commit-sha-placeholder>=-"' {} \; \
         -exec sed -i 's/"-=<GitHub-CI-commit-sha-placeholder>=-"/"'"${COMMIT_SHA}"'"/g' {} \; \
     # Archive static files for better performance
     && find /app/ui -type f \( \
@@ -214,7 +216,8 @@ ARG COMMIT_SHA=NoCommit
 # hadolint ignore=DL3018
 RUN apk add --no-cache curl bash \
     && apk add --no-cache --virtual .build-compress gzip brotli zstd \
-    && find /srv/assets -type f -name "SettingsPage.*.js" \
+    RUN find "${PHOTOVIEW_UI_PATH}/assets" -type f \( -name "*.js" -o -name "*.mjs" \) \
+        -exec grep -qF -- '"-=<GitHub-CI-commit-sha-placeholder>=-"' {} \; \
         -exec sed -i 's/"-=<GitHub-CI-commit-sha-placeholder>=-"/"'"${COMMIT_SHA}"'"/g' {} \; \
     # Archive static files for better performance
     && find /srv -type f \( \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated the UI build Docker stage to install npm with `--no-audit --no-fund` and to run `npm ci` with the same flags.
- Fixed the commit SHA/version placeholder replacement in the Docker images: instead of replacing the placeholder only in `SettingsPage.*.js`, the Docker build now searches all generated `*.js` and `*.mjs` files under the UI assets directory (and `/srv/assets` in the proxy/runtime image) and replaces the `GitHub-CI-commit-sha` placeholder with `COMMIT_SHA` when present.

## Benefits

- Prevents the Settings page from showing an incorrect or placeholder commit/version when the bundled output filenames (e.g., for Settings-related chunks) change.
- Ensures the embedded commit/version is consistently updated in the shipped static UI assets, improving the accuracy of the “version” information users and support teams rely on.

## Risks

- Because the placeholder replacement is applied to all matching `*.js`/`*.mjs` assets (not just SettingsPage files), a misconfigured `COMMIT_SHA` build argument would propagate the wrong value into more UI bundles.
- If the placeholder is unexpectedly present in additional assets, those bundles would also be affected (though the replacement is gated to files that actually contain the exact placeholder string).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->