### PR TITLE
Bump Node version to 24 LTS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -260,7 +260,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "24"
           check-latest: true
 
       - name: Test code sync

--- a/.github/workflows/update-browserslist.yml
+++ b/.github/workflows/update-browserslist.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "24"
           check-latest: true
 
       - name: Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,17 +65,21 @@ ENV CGO_ENABLED=1
 
 # Download dependencies
 COPY --chmod=0755 scripts/set_compiler_env.sh /app/scripts/
+# hadolint ignore=SC3046
 RUN DEBIAN_FRONTEND=noninteractive source /app/scripts/set_compiler_env.sh
 
 COPY --chmod=0755 scripts/install_build_dependencies.sh /app/scripts/
+# hadolint ignore=SC3046
 RUN set -a && source /env && set +a \
     && DEBIAN_FRONTEND=noninteractive /app/scripts/install_build_dependencies.sh
 
 COPY --chmod=0755 scripts/install_runtime_dependencies.sh /app/scripts/
+# hadolint ignore=SC3046
 RUN set -a && source /env && set +a \
     && DEBIAN_FRONTEND=noninteractive /app/scripts/install_runtime_dependencies.sh
 
 WORKDIR /dependencies
+# hadolint ignore=SC3046
 RUN --mount=type=bind,from=dependencies,source=/dependencies/,target=/dependencies/ \
     set -a && source /env && set +a \
     && git config --global --add safe.directory /app \
@@ -90,7 +94,7 @@ RUN --mount=type=bind,from=dependencies,source=/dependencies/,target=/dependenci
 WORKDIR /app/api
 COPY api/go.mod api/go.sum /app/api/
 # DL3062 is not right with latest Go in module-aware mode (default mode).
-# hadolint ignore=DL3062
+# hadolint ignore=DL3062,SC3046
 RUN set -a && source /env && set +a \
     && go env \
     && go mod download \
@@ -103,6 +107,7 @@ RUN set -a && source /env && set +a \
         github.com/Kagami/go-face
 
 COPY api /app/api
+# hadolint ignore=SC3046
 RUN set -a && source /env && set +a \
     && go env \
     && go build -v -o photoview .
@@ -121,7 +126,7 @@ RUN groupadd -g 999 photoview \
     && useradd -r -u 999 -g photoview -m photoview
 
 # Install required dependencies
-COPY --chmod=0755 scripts/install_runtime_dependencies.sh /app/scripts/
+COPY --chmod=0755 scripts/install_runtime_dependencies.sh scripts/docker-healthcheck.sh /app/scripts/
 WORKDIR /dependencies
 RUN --mount=type=bind,from=dependencies,source=/dependencies/,target=/dependencies/ \
     # Create log folder
@@ -176,13 +181,11 @@ ENV PHOTOVIEW_MEDIA_CACHE=/home/photoview/media-cache
 EXPOSE ${PHOTOVIEW_LISTEN_PORT}
 
 HEALTHCHECK --interval=60s --timeout=10s --start-period=10s --retries=2 \
-    CMD curl --fail "http://localhost:${PHOTOVIEW_LISTEN_PORT}${PHOTOVIEW_API_ENDPOINT}/graphql" \
-        -X POST -H 'Content-Type: application/json' \
-        --data-raw '{"operationName":"CheckInitialSetup","variables":{},"query":"query CheckInitialSetup { siteInfo { initialSetup }}"}' \
-    || exit 1
+    CMD ["/app/scripts/docker-healthcheck.sh"]
 
 LABEL org.opencontainers.image.source=https://github.com/kkovaletp/photoview/
 LABEL org.opencontainers.image.licenses="AGPL-3.0-only AND LicenseRef-Photoview-Ethical-Use"
+# hadolint ignore=DL3066
 USER photoview
 ENTRYPOINT ["/app/photoview"]
 
@@ -242,8 +245,8 @@ LABEL org.opencontainers.image.source=https://github.com/kkovaletp/photoview/
 LABEL org.opencontainers.image.licenses="AGPL-3.0-only AND LicenseRef-Photoview-Ethical-Use"
 
 HEALTHCHECK --interval=60s --timeout=5s --start-period=10s --retries=2 \
-    CMD curl -kfsS "https://localhost:${HTTPS_PORT}/health-check" \
-    || exit 1
+    CMD ["bash", "-c", "curl -kfsS \"https://localhost:${HTTPS_PORT}/health-check\" || exit 1"]
 
 # Switch to non-root user
+# hadolint ignore=DL3066
 USER caddyuser

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ### Build UI ###
-FROM --platform=${BUILDPLATFORM:-linux/amd64} node:20 AS ui
+FROM --platform=${BUILDPLATFORM:-linux/amd64} node:24 AS ui
 # See for details: https://github.com/hadolint/hadolint/wiki/DL4006
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 

--- a/scripts/docker-healthcheck.sh
+++ b/scripts/docker-healthcheck.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+curl --fail \
+        "http://localhost:${PHOTOVIEW_LISTEN_PORT}${PHOTOVIEW_API_ENDPOINT}/graphql" \
+        -X POST \
+        -H 'Content-Type: application/json' \
+        --data-raw '{"operationName":"CheckInitialSetup","variables":{},"query":"query CheckInitialSetup { siteInfo { initialSetup }}"}' \
+    || exit 1

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -83,7 +83,7 @@
         "vitest": "^3.2.6"
       },
       "engines": {
-        "node": ">=20.20.0"
+        "node": ">=24.0.0"
       }
     },
     "node_modules/@actions/core": {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -83,7 +83,7 @@
         "vitest": "^3.2.6"
       },
       "engines": {
-        "node": ">=24.0.0"
+        "node": "^24.0.0"
       }
     },
     "node_modules/@actions/core": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -26,7 +26,7 @@
     "lintTranslations": "i18next-cli lint"
   },
   "engines": {
-    "node": ">=24.0.0"
+    "node": "^24.0.0"
   },
   "dependencies": {
     "@apollo/client": "~3.14.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -26,7 +26,7 @@
     "lintTranslations": "i18next-cli lint"
   },
   "engines": {
-    "node": ">=20.20.0"
+    "node": ">=24.0.0"
   },
   "dependencies": {
     "@apollo/client": "~3.14.0",


### PR DESCRIPTION
This PR is part of the #848 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR updates the project to Node.js 24 LTS across:

- UI Docker builds
- UI package engine requirements
- UI bundle tests
- Browserslist update workflows

It also adds a Bash Docker health-check script and updates Dockerfile health-check commands and Hadolint suppressions.

## Benefits

- Aligns development, build, test, and automation environments on Node.js 24.
- Supports the current Node.js LTS release.
- Restricts UI installation to Node.js 24.x.
- Provides a dedicated GraphQL health check for the release image.
- Resolves the targeted Hadolint warnings.

## Risks

- Builds and workflows can fail if runners, Docker images, or local environments do not support Node.js 24.
- Dependencies or build tools that support Node.js 20 may require updates for Node.js 24.
- The `^24.0.0` engine constraint rejects Node.js versions newer than 24.x.
- The new health check can report the container as unhealthy if the local Photoview endpoint or `CheckInitialSetup` request fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->